### PR TITLE
Extend sdo mappings

### DIFF
--- a/sdo/access_sdo_context.jsonld
+++ b/sdo/access_sdo_context.jsonld
@@ -1,18 +1,42 @@
 {
   "@context": {
     "sdo": "https://schema.org/",
-    "Access" : "sdo:EntryPoint",
+    "Access": "sdo:EntryPoint",
     "identifier": {
       "@id": "sdo:identifier",
       "@type": "sdo:Text"
     },
     "landingPage": {
-        "@id": "sdo:url",
-        "@type": "sdo:URL"
+      "@id": "sdo:url",
+      "@type": "sdo:URL"
     },
     "accessURL": {
-        "@id": "sdo:url",
-        "@type": "sdo:URL"
+      "@id": "sdo:url",
+      "@type": "sdo:URL"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "types": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Thing"
+    },
+    "authorizations": {
+      "@id": "sdo:permissionType",
+      "@type": "sdo:DigitalDocumentPermissionType"
+    },
+    "authentications": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/activity_sdo_context.jsonld
+++ b/sdo/activity_sdo_context.jsonld
@@ -23,6 +23,38 @@
       "@type": "sdo:DateTime"
     },
     "location": "sdo:location",
-    "performedBy": "sdo:agent"
+    "performedBy": "sdo:agent",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:DateTime"
+    },
+    "duration": {
+      "@id": "sdo:activityDuration",
+      "@type": "sdo:Thing"
+    },
+    "keywords": {
+      "@id": "sdo:keywords",
+      "@type": "sdo:Thing"
+    },
+    "input": {
+      "@id": "sdo:isBasedOn",
+      "@type": "sdo:Thing"
+    },
+    "output": {
+      "@id": "sdo:produces",
+      "@type": "sdo:Thing"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/alternate_identifier_info_sdo_context.jsonld
+++ b/sdo/alternate_identifier_info_sdo_context.jsonld
@@ -4,6 +4,10 @@
     "identifier": {
       "@id": "sdo:identifier",
       "@type": "sdo:Text"
+    },
+    "identifierSource": {
+      "@id": "sdo:Property",
+      "@type": "sdo:Text"
     }
   }
 }

--- a/sdo/anatomical_part_sdo_context.jsonld
+++ b/sdo/anatomical_part_sdo_context.jsonld
@@ -9,6 +9,18 @@
     "name": {
       "@id": "sdo:name",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/biological_entity_sdo_context.jsonld
+++ b/sdo/biological_entity_sdo_context.jsonld
@@ -9,6 +9,18 @@
     "name": {
       "@id": "sdo:name",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/category_values_pair_sdo_context.jsonld
+++ b/sdo/category_values_pair_sdo_context.jsonld
@@ -9,6 +9,10 @@
     "categoryIRI": {
       "@id": "sdo:url",
       "@type": "sdo:URL"
+    },
+    "values": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:Thing"
     }
   }
 }

--- a/sdo/consent_info_sdo_context.jsonld
+++ b/sdo/consent_info_sdo_context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "sdo": "https://schema.org/"
+  }
+}

--- a/sdo/data_acquisition_sdo_context.jsonld
+++ b/sdo/data_acquisition_sdo_context.jsonld
@@ -1,5 +1,5 @@
 {
-"@context": {
+  "@context": {
     "sdo": "https://schema.org/",
     "DataAcquisition": "sdo:CreateAction",
     "identifier": {
@@ -14,15 +14,55 @@
       "@id": "sdo:description",
       "@type": "sdo:Text"
     },
-   "startDate": {
-        "@id": "sdo:startTime",
-        "@type": "sdo:DateTime"
+    "startDate": {
+      "@id": "sdo:startTime",
+      "@type": "sdo:DateTime"
     },
     "endDate": {
-         "@id": "sdo:endTime",
-         "@type": "sdo:DateTime"
+      "@id": "sdo:endTime",
+      "@type": "sdo:DateTime"
     },
     "location": "sdo:location",
-    "performedBy": "sdo:agent"
+    "performedBy": "sdo:agent",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:DateTime"
+    },
+    "duration": {
+      "@id": "sdo:activityDuration",
+      "@type": "sdo:Thing"
+    },
+    "keywords": {
+      "@id": "sdo:keywords",
+      "@type": "sdo:Thing"
+    },
+    "input": {
+      "@id": "sdo:isBasedOn",
+      "@type": "sdo:Thing"
+    },
+    "output": {
+      "@id": "sdo:produces",
+      "@type": "sdo:Thing"
+    },
+    "uses": {
+      "@id": "sdo:instrument",
+      "@type": "sdo:Thing"
+    },
+    "measures": {
+      "@id": "sdo:variableMeasured",
+      "@type": "sdo:Thing"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
- }
+  }
+}

--- a/sdo/data_analysis_sdo_context.jsonld
+++ b/sdo/data_analysis_sdo_context.jsonld
@@ -15,12 +15,60 @@
       "@type": "sdo:Text"
     },
     "startDate": {
-        "@id": "sdo:startTime",
-        "@type": "sdo:DateTime"
+      "@id": "sdo:startTime",
+      "@type": "sdo:DateTime"
     },
     "endDate": {
-        "@id": "sdo:endTime",
-        "@type": "sdo:DateTime"
+      "@id": "sdo:endTime",
+      "@type": "sdo:DateTime"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:DateTime"
+    },
+    "duration": {
+      "@id": "sdo:activityDuration",
+      "@type": "sdo:Thing"
+    },
+    "location": {
+      "@id": "sdo:location",
+      "@type": "sdo:Thing"
+    },
+    "performedBy": {
+      "@id": "sdo:agent",
+      "@type": "sdo:Thing"
+    },
+    "keywords": {
+      "@id": "sdo:keywords",
+      "@type": "sdo:Thing"
+    },
+    "input": {
+      "@id": "sdo:isBasedOn",
+      "@type": "sdo:Thing"
+    },
+    "output": {
+      "@id": "sdo:produces",
+      "@type": "sdo:Thing"
+    },
+    "uses": {
+      "@id": "sdo:instrument",
+      "@type": "sdo:Thing"
+    },
+    "measures": {
+      "@id": "sdo:variableMeasured",
+      "@type": "sdo:Thing"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/data_repository_sdo_context.jsonld
+++ b/sdo/data_repository_sdo_context.jsonld
@@ -16,6 +16,35 @@
     },
     "licenses": "sdo:license",
     "version": "sdo:version",
-    "publishers": "sdo:publisher"
+    "publishers": "sdo:publisher",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:Text"
+    },
+    "scopes": "sdo:identifier",
+    "types": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Thing"
+    },
+    "aggregatorOf": {
+      "@id": "sdo:includedInDataCatalog",
+      "@type": "sdo:DataCatalog"
+    },
+    "access": {
+      "@id": "sdo:accessMode",
+      "@type": "sdo:EntryPoint"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/data_standard_sdo_context.jsonld
+++ b/sdo/data_standard_sdo_context.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "sdo": "https://schema.org/",
     "DataStandard": "sdo:CreativeWork",
-     "identifier": {
+    "identifier": {
       "@id": "sdo:identifier",
       "@type": "sdo:Text"
     },
@@ -15,6 +15,19 @@
       "@type": "sdo:Text"
     },
     "licenses": "sdo:license",
-    "version": "sdo:version"
+    "version": "sdo:version",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "type": "sdo:Property",
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/data_type_sdo_context.jsonld
+++ b/sdo/data_type_sdo_context.jsonld
@@ -9,10 +9,10 @@
       "@id": "sdo:Property"
     },
     "platform": {
-       "@id": "sdo:Property"
+      "@id": "sdo:Property"
     },
     "instrument": {
-        "@id": "sdo:instrument"
+      "@id": "sdo:instrument"
     }
   }
 }

--- a/sdo/dataset_distribution_sdo_context.jsonld
+++ b/sdo/dataset_distribution_sdo_context.jsonld
@@ -27,8 +27,36 @@
       "@type": "sdo:EntryPoint"
     },
     "size": {
-        "@id": "sdo:contentSize",
-        "@type": "sdo:Text"
+      "@id": "sdo:contentSize",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:DataCatalog"
+    },
+    "curationStatus": {
+      "@id": "sdo:ratingValue",
+      "@type": "sdo:Text"
+    },
+    "conformsTo": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    },
+    "qualifiers": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    },
+    "formats": {
+      "@id": "sdo:encodingFormat",
+      "@type": "sdo:Text"
+    },
+    "unit": {
+      "@id": "sdo:unitText",
+      "@type": "sdo:Text"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/dataset_sdo_context.jsonld
+++ b/sdo/dataset_sdo_context.jsonld
@@ -19,8 +19,8 @@
     "dates": "sdo:temporalCoverage",
     "spatialCoverage": "sdo:spatialCoverage",
     "storedIn": {
-        "@id": "sdo:includedInDataCatalog",
-        "@type": "sdo:DataCatalog"
+      "@id": "sdo:includedInDataCatalog",
+      "@type": "sdo:DataCatalog"
     },
     "distributions": {
       "@id": "sdo:distribution",
@@ -30,16 +30,60 @@
     "citations": "sdo:citation",
     "producedBy": "sdo:producer",
     "creators": {
-        "@id": "sdo:creator",
-        "@type": "sdo:Thing"
+      "@id": "sdo:creator",
+      "@type": "sdo:Thing"
     },
     "licenses": "sdo:license",
     "isAbout": "sdo:about",
     "hasPart": {
-        "@id": "sdo:hasPart",
-        "@type": "sdo:Dataset"
+      "@id": "sdo:hasPart",
+      "@type": "sdo:Dataset"
     },
     "acknowledges": "sdo:funder",
-    "dimensions": "sdo:variableMeasured"
+    "dimensions": "sdo:variableMeasured",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "types": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Thing"
+    },
+    "availability": {
+      "@id": "sdo:conditionsOfAccess",
+      "@type": "sdo:Text"
+    },
+    "refinement": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    },
+    "aggregation": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    },
+    "privacy": {
+      "@id": "sdo:conditionsOfAccess",
+      "@type": "sdo:Text"
+    },
+    "citationCount": {
+      "@id": "sdo:value",
+      "@type": "sdo:Number"
+    },
+    "keywords": {
+      "@id": "sdo:keywords",
+      "@type": "sdo:Thing"
+    },
+    "version": {
+      "@id": "sdo:version",
+      "@type": "sdo:Thing"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/date_info_sdo_context.jsonld
+++ b/sdo/date_info_sdo_context.jsonld
@@ -1,12 +1,12 @@
 {
- "@context": {
+  "@context": {
     "sdo": "https://schema.org/",
     "Date": "sdo:DateTime",
     "date": {
-        "@id": "sdo:Property"
+      "@id": "sdo:Property"
     },
-    "type":{
-        "@id": "sdo:Property"
+    "type": {
+      "@id": "sdo:Property"
     }
-   }
+  }
 }

--- a/sdo/dimension_sdo_context.jsonld
+++ b/sdo/dimension_sdo_context.jsonld
@@ -13,6 +13,46 @@
     "description": {
       "@id": "sdo:description",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "types": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Thing"
+    },
+    "datatype": {
+      "@id": "sdo:measuredValue",
+      "@type": "sdo:DataType"
+    },
+    "values": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:Thing"
+    },
+    "unit": {
+      "@id": "sdo:unitText",
+      "@type": "sdo:Text"
+    },
+    "isAbout": {
+      "@id": "sdo:about",
+      "@type": "sdo:Text"
+    },
+    "consentInformation": {
+      "@id": "sdo:permissionType",
+      "@type": "sdo:DigitalDocumentPermissionType"
+    },
+    "partOf": {
+      "@id": "sdo:isPartOf",
+      "@type": "sdo:Thing"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/disease_sdo_context.jsonld
+++ b/sdo/disease_sdo_context.jsonld
@@ -9,6 +9,26 @@
     "name": {
       "@id": "sdo:name",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:Text"
+    },
+    "diseaseStatus": {
+      "@id": "sdo:healthCondition",
+      "@type": "sdo:MedicalCondition"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/genome_location_sdo_context.jsonld
+++ b/sdo/genome_location_sdo_context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "sdo": "https://schema.org/"
+  }
+}

--- a/sdo/grant_sdo_context.jsonld
+++ b/sdo/grant_sdo_context.jsonld
@@ -10,6 +10,34 @@
     "name": {
       "@id": "sdo:name",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "funds": {
+      "@id": "sdo:fundedItem",
+      "@type": "sdo:Thing"
+    },
+    "funders": {
+      "@id": "sdo:funder",
+      "@type": "sdo:Thing"
+    },
+    "awardees": {
+      "@id": "sdo:endorsee",
+      "@type": "sdo:Thing"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:Thing"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/identifier_info_sdo_context.jsonld
+++ b/sdo/identifier_info_sdo_context.jsonld
@@ -4,8 +4,8 @@
     "Identifier": "sdo:Thing",
     "identifier": "sdo:identifier",
     "identifierSource": {
-       "@id": "sdo:Property",
-       "@type": "sdo:Text"
+      "@id": "sdo:Property",
+      "@type": "sdo:Text"
     }
   }
 }

--- a/sdo/instrument_sdo_context.jsonld
+++ b/sdo/instrument_sdo_context.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "sdo": "https://schema.org/",
     "Instrument": "sdo:Product",
-     "identifier": {
+    "identifier": {
       "@id": "sdo:identifier",
       "@type": "sdo:Text"
     },
@@ -10,9 +10,30 @@
       "@id": "sdo:name",
       "@type": "sdo:Text"
     },
-    "description":{
-        "@id": "sdo:description",
-        "@type": "sdo:Text"
+    "description": {
+      "@id": "sdo:description",
+      "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "type": "sdo:Property",
+    "isUsedBy": {
+      "@id": "sdo:workExample",
+      "@type": "sdo:Thing"
+    },
+    "manufacturer": {
+      "@id": "sdo:manufacturer",
+      "@type": "sdo:Organization"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/license_sdo_context.jsonld
+++ b/sdo/license_sdo_context.jsonld
@@ -11,8 +11,40 @@
       "@type": "sdo:Text"
     },
     "version": {
-        "@id": "sdo:version",
-        "@type": "sdo:Text"
+      "@id": "sdo:version",
+      "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:Text"
+    },
+    "licensingAuthority": {
+      "@id": "sdo:authenticator",
+      "@type": "sdo:Organization"
+    },
+    "creators": {
+      "@id": "sdo:creator",
+      "@type": "sdo:Thing"
+    },
+    "consentInformation": {
+      "@id": "sdo:permissionType",
+      "@type": "sdo:DigitalDocumentPermissionType"
+    },
+    "dataUseConditions": {
+      "@id": "sdo:conditionsOfAccess",
+      "@type": "sdo:Text"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/material_sdo_context.jsonld
+++ b/sdo/material_sdo_context.jsonld
@@ -11,10 +11,50 @@
       "@type": "sdo:Text"
     },
     "description": {
-        "@id": "sdo:name",
-        "@type": "sdo:Text"
+      "@id": "sdo:name",
+      "@type": "sdo:Text"
     },
     "spatialCoverage": "sdo:spatialCoverage",
-    "roles": "sdo:roleName"
+    "roles": "sdo:roleName",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "derivesFrom": {
+      "@id": "sdo:isBasedOn",
+      "@type": "sdo:Thing"
+    },
+    "bearerOfDisease": {
+      "@id": "sdo:diagnosis",
+      "@type": "sdo:MedicalCondition"
+    },
+    "taxonomy": {
+      "@id": "sdo:category",
+      "@type": "sdo:Thing"
+    },
+    "involvedInBiologicalEntity": {
+      "@id": "sdo:potentialAction",
+      "@type": "sdo:Thing"
+    },
+    "characteristics": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    },
+    "consentInformation": {
+      "@id": "sdo:permissionType",
+      "@type": "sdo:DigitalDocumentPermissionType"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:DigitalDocumentPermissionType"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/molecular_entity_sdo_context.jsonld
+++ b/sdo/molecular_entity_sdo_context.jsonld
@@ -2,13 +2,50 @@
   "@context": {
     "sdo": "https://schema.org/",
     "BiologicalEntity": "sdo:Thing",
-     "identifier": {
+    "identifier": {
       "@id": "sdo:identifier",
       "@type": "sdo:Text"
     },
     "name": {
       "@id": "sdo:name",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "description": {
+      "@id": "sdo:description",
+      "@type": "sdo:Text"
+    },
+    "taxonomy": {
+      "@id": "sdo:category",
+      "@type": "sdo:Thing"
+    },
+    "characteristics": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    },
+    "roles": "sdo:roleName",
+    "involvedInProcess": {
+      "@id": "sdo:potentialAction",
+      "@type": "sdo:Thing"
+    },
+    "relatedEntities": {
+      "@id": "sdo:relatedLink",
+      "@type": "@id"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "@id"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/organization_sdo_context.jsonld
+++ b/sdo/organization_sdo_context.jsonld
@@ -7,20 +7,32 @@
       "@type": "sdo:Text"
     },
     "name": {
-        "@id": "sdo:name",
-        "@type": "sdo:Text"
+      "@id": "sdo:name",
+      "@type": "sdo:Text"
     },
     "abbreviation": {
-        "@id": "sdo:name",
-        "@type": "sdo:Text"
+      "@id": "sdo:name",
+      "@type": "sdo:Text"
     },
     "location": {
-        "@id": "sdo:address",
-        "@type": "sdo:Text"
+      "@id": "sdo:address",
+      "@type": "sdo:Text"
     },
     "roles": {
-        "@id": "sdo:roleName",
-        "@type": "sdo:Text"
+      "@id": "sdo:roleName",
+      "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/person_sdo_context.jsonld
+++ b/sdo/person_sdo_context.jsonld
@@ -8,6 +8,16 @@
     "fullName": "sdo:name",
     "email": "sdo:email",
     "affiliations": "sdo:affiliation",
-    "roles": "sdo:roleName"
+    "roles": "sdo:roleName",
+    "alternateIdentifiers": "sdo:identifier",
+    "relatedIdentifiers": "sdo:identifier",
+    "middleInitial": {
+      "@id": "sdo:additionalName",
+      "@type": "sdo:Text"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/place_sdo_context.jsonld
+++ b/sdo/place_sdo_context.jsonld
@@ -15,16 +15,24 @@
       "@type": "sdo:Text"
     },
     "postalAddress": {
-        "@id": "sdo:address",
-        "@type": "sdo:PostalAddress"
+      "@id": "sdo:address",
+      "@type": "sdo:PostalAddress"
     },
     "geometry": {
-        "@id": "sdo:geospatiallyContains",
-        "@type": "sdo:GeospatialGeometry"
+      "@id": "sdo:geospatiallyContains",
+      "@type": "sdo:GeospatialGeometry"
     },
     "coordinates": {
-         "@id": "sdo:geo",
-         "@type": "sdo:GeoCoordinates"
+      "@id": "sdo:geo",
+      "@type": "sdo:GeoCoordinates"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
     }
   }
 }

--- a/sdo/provenance_sdo_context.jsonld
+++ b/sdo/provenance_sdo_context.jsonld
@@ -12,6 +12,26 @@
     "description": {
       "@id": "sdo:description",
       "@type": "sdo:Text"
+    },
+    "transformationFile": {
+      "@id": "sdo:url",
+      "@type": "@id"
+    },
+    "ingestMethod": {
+      "@id": "sdo:procedure",
+      "@type": "sdo:Text"
+    },
+    "ingestTarget": {
+      "@id": "sdo:isBasedOn",
+      "@type": "@id"
+    },
+    "filePattern": {
+      "@id": "sdo:valuePattern",
+      "@type": "sdo:Text"
+    },
+    "ingestTimestamp": {
+      "@id": "sdo:uploadDate",
+      "@type": "sdo:Date"
     }
   }
 }

--- a/sdo/publication_sdo_context.jsonld
+++ b/sdo/publication_sdo_context.jsonld
@@ -14,6 +14,24 @@
     "publicationVenue": "sdo:publication",
     "authorList": "sdo:author",
     "authors": "sdo:author",
-    "acknowledges": "sdo:funder"
+    "acknowledges": "sdo:funder",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:Text"
+    },
+    "authorsList": "sdo:author",
+    "licenses": "sdo:license",
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/related_identifier_info_sdo_context.jsonld
+++ b/sdo/related_identifier_info_sdo_context.jsonld
@@ -13,6 +13,14 @@
     "description": {
       "@id": "sdo:description",
       "@type": "sdo:Text"
+    },
+    "identifierSource": {
+      "@id": "sdo:Property",
+      "@type": "sdo:Text"
+    },
+    "relationType": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:Thing"
     }
   }
 }

--- a/sdo/software_sdo_context.jsonld
+++ b/sdo/software_sdo_context.jsonld
@@ -15,6 +15,30 @@
       "@type": "sdo:Text"
     },
     "licenses": "sdo:license",
-    "version": "sdo:version"
+    "version": "sdo:version",
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:Text"
+    },
+    "isUsedBy": {
+      "@id": "sdo:workExample",
+      "@type": "sdo:Thing"
+    },
+    "manufacturer": {
+      "@id": "sdo:manufacturer",
+      "@type": "sdo:Organization"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
+    }
   }
 }

--- a/sdo/study_group_sdo_context.jsonld
+++ b/sdo/study_group_sdo_context.jsonld
@@ -13,6 +13,34 @@
     "description": {
       "@id": "sdo:description",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "keywords": {
+      "@id": "sdo:keywords",
+      "@type": "sdo:Thing"
+    },
+    "size": {
+      "@id": "sdo:contentSize",
+      "@type": "sdo:Text"
+    },
+    "members": {
+      "@id": "sdo:member",
+      "@type": "sdo:Thing"
+    },
+    "consentInformation": {
+      "@id": "sdo:permissionType",
+      "@type": "sdo:DigitalDocumentPermissionType"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/study_sdo_context.jsonld
+++ b/sdo/study_sdo_context.jsonld
@@ -13,6 +13,78 @@
     "description": {
       "@id": "sdo:description",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "types": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Thing"
+    },
+    "startDate": {
+      "@id": "sdo:startTime",
+      "@type": "sdo:DateTime"
+    },
+    "endDate": {
+      "@id": "sdo:endTime",
+      "@type": "sdo:DateTime"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:DateTime"
+    },
+    "duration": {
+      "@id": "sdo:activityDuration",
+      "@type": "sdo:Thing"
+    },
+    "location": {
+      "@id": "sdo:location",
+      "@type": "sdo:Thing"
+    },
+    "performedBy": {
+      "@id": "sdo:agent",
+      "@type": "sdo:Thing"
+    },
+    "keywords": {
+      "@id": "sdo:keywords",
+      "@type": "sdo:Thing"
+    },
+    "input": {
+      "@id": "sdo:isBasedOn",
+      "@type": "sdo:Thing"
+    },
+    "output": {
+      "@id": "sdo:produces",
+      "@type": "sdo:Thing"
+    },
+    "schedulesActivity": {
+      "@id": "sdo:potentialAction",
+      "@type": "sdo:Action"
+    },
+    "schedulesDataAcquisition": {
+      "@id": "sdo: measurementTechnique",
+      "@type": "sdo:Thing"
+    },
+    "studyGroups": {
+      "@id": "sdo:member",
+      "@type": "sdo:Thing"
+    },
+    "usesReagent": {
+      "@id": "sdo:supply",
+      "@type": "sdo:Text"
+    },
+    "isAboutBiologicalEntity": {
+      "@id": "sdo:about",
+      "@type": "sdo:Thing"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/taxonomic_info_sdo_context.jsonld
+++ b/sdo/taxonomic_info_sdo_context.jsonld
@@ -9,6 +9,18 @@
     "name": {
       "@id": "sdo:name",
       "@type": "sdo:Text"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }

--- a/sdo/treatment_sdo_context.jsonld
+++ b/sdo/treatment_sdo_context.jsonld
@@ -21,6 +21,62 @@
     "endDate": {
       "@id": "sdo:endTime",
       "@type": "sdo:DateTime"
+    },
+    "alternateIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "relatedIdentifiers": {
+      "@id": "sdo:identifier",
+      "@type": "sdo:Text"
+    },
+    "dates": {
+      "@id": "sdo:temporalCoverage",
+      "@type": "sdo:DateTime"
+    },
+    "duration": {
+      "@id": "sdo:activityDuration",
+      "@type": "sdo:Thing"
+    },
+    "location": {
+      "@id": "sdo:location",
+      "@type": "sdo:Thing"
+    },
+    "performedBy": {
+      "@id": "sdo:agent",
+      "@type": "sdo:Thing"
+    },
+    "keywords": {
+      "@id": "sdo:keywords",
+      "@type": "sdo:Thing"
+    },
+    "input": {
+      "@id": "sdo:isBasedOn",
+      "@type": "sdo:Thing"
+    },
+    "output": {
+      "@id": "sdo:produces",
+      "@type": "sdo:Thing"
+    },
+    "agent": {
+      "@id": "sdo:procedureType",
+      "@type": "sdo:Thing"
+    },
+    "intensity": {
+      "@id": "sdo:valueReference",
+      "@type": "sdo:Thing"
+    },
+    "concomitance": {
+      "@id": "sdo:value",
+      "@type": "sdo:Boolean"
+    },
+    "order": {
+      "@id": "sdo:position",
+      "@type": "sdo:Integer"
+    },
+    "extraProperties": {
+      "@id": "sdo:additionalProperty",
+      "@type": "sdo:PropertyValue"
     }
   }
 }


### PR DESCRIPTION
These are the DATS schema extensions for SDO. They are based on this [google doc spreadsheet](https://docs.google.com/spreadsheets/d/10CvWkHPD5qXxqawU7dexYl5PG5OIYJqDiIPuXAnAUsw/edit?usp=sharing) and our previous discussions.



